### PR TITLE
Remove active_support dependency for the CLI

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -321,3 +321,10 @@ Style/Send:
 
 Style/UnneededPercentQ:
   Enabled: true
+
+Style/RegexpLiteral:
+  Enabled: false
+
+RSpec/FilePath:
+  Enabled: false
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     archfiend (0.1.0)
-      activesupport (~> 5)
       oj (~> 3.6)
       thor (~> 0.20)
 

--- a/archfiend.gemspec
+++ b/archfiend.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activesupport', '~> 5' # CLI
   spec.add_development_dependency 'activerecord', '~> 5' # For specs
   spec.add_development_dependency 'bundler', '~> 1.15'
   spec.add_development_dependency 'config', '~> 1.7'

--- a/lib/archfiend/cli.rb
+++ b/lib/archfiend/cli.rb
@@ -6,6 +6,8 @@ require 'archfiend/generators/daemon'
 require 'archfiend/generators/options'
 require 'archfiend/generators/extensions'
 require 'archfiend/generators/utils'
+require 'archfiend/core_ext/string/camelize'
+require 'archfiend/core_ext/string/underscore'
 
 module Archfiend
   class CLI < Thor

--- a/lib/archfiend/core_ext/string/camelize.rb
+++ b/lib/archfiend/core_ext/string/camelize.rb
@@ -1,0 +1,17 @@
+module Archfiend
+  module String
+    module Camelize
+      # rubocop:disable Style/PerlBackrefs
+      # @return [String] String in the camelized format, first letter capital
+      def camelize
+        string = sub(/^[a-z\d]*/, &:capitalize)
+        string.gsub!(/(?:_|(\/))([a-z\d]*)/i) { "#{$1}#{$2.capitalize}" }
+        string.gsub!('/'.freeze, '::'.freeze)
+        string
+      end
+      # rubocop:enable Style/PerlBackrefs
+    end
+  end
+end
+
+String.include(Archfiend::String::Camelize) unless ''.respond_to?(:camelize)

--- a/lib/archfiend/core_ext/string/underscore.rb
+++ b/lib/archfiend/core_ext/string/underscore.rb
@@ -1,0 +1,19 @@
+module Archfiend
+  module String
+    module Underscore
+      # @return [String] String in the lowercase underscore format
+      def underscore
+        return self unless /[A-Z-]|::/.match?(self)
+
+        word = gsub('::'.freeze, '/'.freeze)
+        word.gsub!(/([A-Z\d]+)([A-Z][a-z])/, '\1_\2'.freeze)
+        word.gsub!(/([a-z\d])([A-Z])/, '\1_\2'.freeze)
+        word.tr!('-'.freeze, '_'.freeze)
+        word.downcase!
+        word
+      end
+    end
+  end
+end
+
+String.include(Archfiend::String::Underscore) unless ''.respond_to?(:underscore)

--- a/lib/archfiend/generators/daemon.rb
+++ b/lib/archfiend/generators/daemon.rb
@@ -1,4 +1,3 @@
-require 'active_support/inflector'
 require 'thor'
 
 module Archfiend

--- a/spec/archfiend/application_spec.rb
+++ b/spec/archfiend/application_spec.rb
@@ -1,5 +1,5 @@
 require 'active_record'
-require 'active_support/all'
+require 'active_support/time'
 require 'config'
 
 RSpec.describe Archfiend::Application do

--- a/spec/archfiend/core_ext/string/camelize_spec.rb
+++ b/spec/archfiend/core_ext/string/camelize_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe Archfiend::String::Camelize do
+  context 'when included in some String class' do
+    let(:new_string) { Class.new(String).tap { |kl| kl.include(described_class) } }
+
+    def test_string(value)
+      new_string.new(value)
+    end
+
+    describe '#camelize' do
+      specify { expect(test_string('foo_bar').camelize).to eq('FooBar') }
+      specify { expect(test_string('foo_bar/baz').camelize).to eq('FooBar::Baz') }
+      specify { expect(test_string('foo_barBaz9').camelize).to eq('FooBarbaz9') }
+      specify { expect(test_string('9foo').camelize).to eq('9foo') }
+      specify { expect(test_string('')).to eq('') }
+    end
+  end
+end

--- a/spec/archfiend/core_ext/string/underscores_spec.rb
+++ b/spec/archfiend/core_ext/string/underscores_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe Archfiend::String::Underscore do
+  context 'when included in some String class' do
+    let(:new_string) { Class.new(String).tap { |kl| kl.include(described_class) } }
+
+    def test_string(value)
+      new_string.new(value)
+    end
+
+    describe '#underscore' do
+      specify { expect(test_string('FooBar').underscore).to eq('foo_bar') }
+      specify { expect(test_string('FooBar::Baz').underscore).to eq('foo_bar/baz') }
+      specify { expect(test_string('FooBarbaz9').underscore).to eq('foo_barbaz9') }
+      specify { expect(test_string('9foo').underscore).to eq('9foo') }
+      specify { expect(test_string('')).to eq('') }
+    end
+  end
+end


### PR DESCRIPTION
Remove active_support dependency for the CLI
It was only used for `camelize` and `underscore`, this PR adds those methods.
This results in a 400ms (60%) CLI startup speedup, and some CLI RSS reduction.

#### after

```bash
 name                                            time   RSS after
----------------------------------------------------------------
  rubygems/bundler_version_finder                  1ms   5325KB
  thor/command                                     1ms   6070KB
  thor/core_ext/hash_with_indifferent_access       1ms   6103KB
  thor/core_ext/ordered_hash                       1ms   6134KB
  thor/error                                       1ms   6137KB
  thor/invocation                                  1ms   6224KB
  thor/parser/argument                             1ms   6249KB
  thor/parser/arguments                            1ms   6298KB
  thor/parser/option                               1ms   6358KB
  thor/parser/options                              1ms   6413KB
  thor/parser                                     17ms   6413KB
  thor/shell                                       1ms   6431KB
  thor/line_editor/basic                           0ms   6440KB
  readline                                         1ms   6820KB
  thor/line_editor/readline                        2ms   6820KB
  thor/line_editor                                 7ms   6820KB
  thor/util                                        2ms   6890KB
  thor/base                                       77ms   6890KB
  thor                                           147ms   6890KB
  pathname.so                                      1ms   7045KB
  pathname                                         3ms   7045KB
  forwardable/impl                                 0ms   7081KB
  forwardable                                      2ms   7081KB
  archfiend/version                                0ms   7087KB
  thor/group                                       2ms   7162KB
  thor/core_ext/io_binary_read                     0ms   7218KB
  thor/actions/empty_directory                     1ms   7256KB
  thor/actions/create_file                         2ms   7256KB
  thor/actions/create_link                         1ms   7264KB
  thor/actions/directory                           1ms   7282KB
  cgi/escape                                       1ms   7569KB
  cgi/util                                         2ms   7569KB
  strscan                                          1ms   7594KB
  erb                                             14ms   7594KB
  thor/actions/file_manipulation                  15ms   7594KB
  thor/actions/inject_into_file                    1ms   7606KB
  thor/actions                                    54ms   7606KB
  archfiend/generators/daemon                     61ms   7606KB
  archfiend/generators/options                     1ms   7658KB
  archfiend/generators/extensions                  1ms   7686KB
  archfiend/generators/utils                       1ms   7693KB
  archfiend/core_ext/string/camelize               0ms   7694KB
  archfiend/core_ext/string/underscore             0ms   7700KB
----------------------------------------------------------------
./lib/archfiend/cli                              276ms   7700KB
```
#### before

```bash
  name                                                      time   RSS after
--------------------------------------------------------------------------
  rubygems/bundler_version_finder                            1ms   5346KB
  thor/command                                               1ms   6092KB
  thor/core_ext/hash_with_indifferent_access                 1ms   6118KB
  thor/core_ext/ordered_hash                                 1ms   6186KB
  thor/error                                                 0ms   6191KB
  thor/invocation                                            1ms   6257KB
  thor/parser/argument                                       1ms   6277KB
  thor/parser/arguments                                      1ms   6318KB
  thor/parser/option                                         1ms   6381KB
  thor/parser/options                                        1ms   6460KB
  thor/parser                                               17ms   6460KB
  thor/shell                                                 1ms   6488KB
  thor/line_editor/basic                                     0ms   6504KB
  readline                                                   1ms   6889KB
  thor/line_editor/readline                                  2ms   6889KB
  thor/line_editor                                           7ms   6889KB
  thor/util                                                  1ms   6968KB
  thor/base                                                 76ms   6968KB
  thor                                                     143ms   6968KB
  pathname.so                                                1ms   7127KB
  pathname                                                   3ms   7127KB
  forwardable/impl                                           0ms   7160KB
  forwardable                                                1ms   7160KB
  archfiend/version                                          0ms   7165KB
  concurrent/constants                                       0ms   7536KB
  concurrent/utility/engine                                  1ms   7548KB
  concurrent/synchronization/abstract_object                 1ms   7549KB
  concurrent/utility/native_extension_loader                 1ms   7556KB
  concurrent/synchronization/mri_object                      1ms   7836KB
  concurrent/synchronization/jruby_object                    1ms   7841KB
  concurrent/synchronization/rbx_object                      1ms   7843KB
  concurrent/synchronization/truffle_object                  1ms   7852KB
  concurrent/synchronization/object                          1ms   7867KB
  concurrent/synchronization/volatile                        1ms   7883KB
  concurrent/synchronization/abstract_lockable_object        1ms   7884KB
  concurrent/synchronization/mri_lockable_object             1ms   7895KB
  concurrent/synchronization/jruby_lockable_object           1ms   7896KB
  concurrent/synchronization/rbx_lockable_object             1ms   7900KB
  concurrent/synchronization/truffle_lockable_object         1ms   7911KB
  concurrent/synchronization/lockable_object                 1ms   7919KB
  concurrent/synchronization/condition                       1ms   7926KB
  concurrent/synchronization/lock                            1ms   7928KB
  concurrent/synchronization                               111ms   7928KB
  concurrent/collection/map/non_concurrent_map_backend       1ms   7945KB
  concurrent/collection/map/mri_map_backend                  3ms   7945KB
  concurrent/map                                           130ms   7945KB
  active_support/core_ext/array/prepend_and_append           1ms   7945KB
  active_support/core_ext/regexp                             1ms   7946KB
  active_support/core_ext/hash/deep_merge                    1ms   7950KB
  active_support/core_ext/hash/except                        1ms   7952KB
  active_support/core_ext/hash/slice                         1ms   7954KB
  i18n/version                                               1ms   8004KB
  cgi/core                                                   4ms   8298KB
  cgi/escape                                                 1ms   8368KB
  cgi/util                                                   4ms   8368KB
  cgi/cookie                                                 6ms   8368KB
  cgi                                                       28ms   8380KB
  i18n/exceptions                                           29ms   8380KB
  i18n/interpolate/ruby                                      1ms   8390KB
  i18n                                                      46ms   8390KB
  active_support/lazy_load_hooks                             1ms   8394KB
  i18n/config                                                2ms   8405KB
  active_support/i18n                                       75ms   8405KB
  singleton                                                  2ms   8410KB
  active_support/core_ext/kernel/singleton_class             1ms   8413KB
  active_support/core_ext/module/delegation                  3ms   8436KB
  active_support/deprecation/instance_delegator              8ms   8436KB
  securerandom                                               2ms   8468KB
  active_support/notifications/instrumenter                  3ms   8468KB
  mutex_m                                                    2ms   8491KB
  active_support/notifications/fanout                        7ms   8498KB
  active_support/per_thread_registry                         1ms   8510KB
  active_support/notifications                              24ms   8510KB
  active_support/deprecation/behaviors                      25ms   8510KB
  active_support/deprecation/reporting                       3ms   8546KB
  active_support/deprecation/constant_accessor               1ms   8558KB
  active_support/core_ext/module/aliasing                    1ms   8596KB
  active_support/core_ext/array/extract_options              1ms   8609KB
  active_support/deprecation/method_wrappers                 6ms   8609KB
  active_support/deprecation/proxy_wrappers                  1ms   8651KB
  active_support/core_ext/module/deprecation                 1ms   8746KB
  active_support/deprecation                                91ms   8746KB
  active_support/inflector/inflections                     326ms   8746KB
  active_support/multibyte                                   1ms   8790KB
  active_support/core_ext/string/multibyte                   1ms   8790KB
  active_support/inflector/transliterate                    10ms   8800KB
  active_support/inflections                                 2ms   8962KB
  active_support/inflector/methods                           8ms   8964KB
  active_support/core_ext/string/inflections                 1ms   8985KB
  active_support/inflector                                 378ms   8985KB
  thor/group                                                 2ms   9045KB
  thor/core_ext/io_binary_read                               1ms   9099KB
  thor/actions/empty_directory                               1ms   9130KB
  thor/actions/create_file                                   3ms   9130KB
  thor/actions/create_link                                   1ms   9147KB
  thor/actions/directory                                     2ms   9174KB
  strscan                                                    2ms   9532KB
  erb                                                        7ms   9532KB
  thor/actions/file_manipulation                             9ms   9532KB
  thor/actions/inject_into_file                              2ms   9563KB
  thor/actions                                              51ms   9563KB
  archfiend/generators/daemon                              445ms   9563KB
  archfiend/generators/options                               4ms   9635KB
  archfiend/generators/extensions                            2ms   9680KB
  archfiend/generators/utils                                 2ms   9692KB
  archfiend/core_ext/string/camelize                         1ms   9711KB
  archfiend/core_ext/string/underscore                       1ms   9734KB
--------------------------------------------------------------------------
./lib/archfiend/cli                                        662ms   9734KB
```


Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rspec` & `bundle exec rubocop`.

[1]: http://chris.beams.io/posts/git-commit/
