### PR TITLE
Support progname argument and block syntax by MultiLogger and DefaultFormatter

### DIFF
--- a/lib/archfiend/logging/default_formatter.rb
+++ b/lib/archfiend/logging/default_formatter.rb
@@ -2,10 +2,10 @@ module Archfiend
   class Logging
     # Simple formatter that includes both PID and a unique thread id
     class DefaultFormatter < BaseFormatter
-      def call(severity, datetime, _progname, msg)
+      def call(severity, datetime, progname, msg)
         description, _backtrace = description_and_backtrace(severity, msg)
 
-        "#{datetime.utc.iso8601(3)} #{::Process.pid} TID-#{tid} #{severity}: #{description}\n"
+        "#{datetime.utc.iso8601(3)} #{::Process.pid} TID-#{tid} #{severity} -- #{progname}: #{description}\n"
       end
     end
   end

--- a/lib/archfiend/logging/multi_logger.rb
+++ b/lib/archfiend/logging/multi_logger.rb
@@ -13,10 +13,10 @@ module Archfiend
       private
 
       # @return [Object] The return value is forwarded from the first logger that responds to the method_name
-      def method_missing(method_name, *args)
+      def method_missing(method_name, *args, &block)
         return super unless responding_loggers(method_name).any?
 
-        responding_loggers(method_name).map { |l| l.public_send(method_name, *args) }.first
+        responding_loggers(method_name).map { |l| l.public_send(method_name, *args, &block) }.first
       end
 
       def respond_to_missing?(symbol, include_private = false)

--- a/spec/archfiend/logging/default_formatter_spec.rb
+++ b/spec/archfiend/logging/default_formatter_spec.rb
@@ -11,18 +11,18 @@ RSpec.describe Archfiend::Logging::DefaultFormatter do
 
     let(:severity) { 'INFO' }
     let(:datetime) { Time.parse('2018-03-16 12:00:00 UTC') }
-    let(:progname) { 'Test' }
+    let(:progname) { 'Progname' }
 
     context 'when msg is a hash' do
       let(:msg) { {message: 'Test', backtrace: []} }
 
-      it { is_expected.to eq("2018-03-16T12:00:00.000Z 666 TID-TESTTID INFO: Test\n") }
+      it { is_expected.to eq("2018-03-16T12:00:00.000Z 666 TID-TESTTID INFO -- Progname: Test\n") }
     end
 
     context 'when msg is a string' do
       let(:msg) { 'Test' }
 
-      it { is_expected.to eq("2018-03-16T12:00:00.000Z 666 TID-TESTTID INFO: Test\n") }
+      it { is_expected.to eq("2018-03-16T12:00:00.000Z 666 TID-TESTTID INFO -- Progname: Test\n") }
     end
   end
 end

--- a/spec/archfiend/logging/multi_logger_spec.rb
+++ b/spec/archfiend/logging/multi_logger_spec.rb
@@ -1,12 +1,12 @@
 RSpec.describe Archfiend::Logging::MultiLogger do
-  subject(:instance) { described_class.new(loggers) }
+  subject(:multi_logger) { described_class.new(loggers) }
 
   let(:logger1) { instance_double(Logger) }
   let(:logger2) { instance_double(Logger) }
   let(:loggers) { [logger1, logger2] }
 
   describe '#method_missing' do
-    subject { instance.info('test') }
+    subject { multi_logger.info('test') }
 
     context 'when there are responding loggers' do
       it 'forwards method to all responding loggers' do
@@ -27,8 +27,39 @@ RSpec.describe Archfiend::Logging::MultiLogger do
 
     context 'when there are no responding loggers' do
       it 'fails with NoMethodError' do
-        expect { instance.unknown_method('test') }.to raise_exception(NoMethodError)
+        expect { multi_logger.unknown_method('test') }.to raise_exception(NoMethodError)
       end
+    end
+  end
+
+  describe '#info' do
+    let(:logger1) { Logger.new(log1) }
+    let(:logger2) { Logger.new(log2) }
+    let(:log1) { StringIO.new }
+    let(:log2) { StringIO.new }
+
+    specify '#info(message)' do
+      expect do
+        expect do
+          multi_logger.info('the message')
+        end.to change(log1, :string).to(/INFO -- : the message/)
+      end.to change(log2, :string).to(/INFO -- : the message/)
+    end
+
+    specify '#info { message }' do
+      expect do
+        expect do
+          multi_logger.info { 'the message' }
+        end.to change(log1, :string).to(/INFO -- : the message/)
+      end.to change(log2, :string).to(/INFO -- : the message/)
+    end
+
+    specify '#info(progname) { message }' do
+      expect do
+        expect do
+          multi_logger.info('The App') { 'the message' }
+        end.to change(log1, :string).to(/INFO -- The App: the message/)
+      end.to change(log2, :string).to(/INFO -- The App: the message/)
     end
   end
 end


### PR DESCRIPTION
Logger signature was incomplete (see [Logger#info](https://ruby-doc.org/stdlib-2.4.0/libdoc/logger/rdoc/Logger.html#method-i-info)) , now it does not ignore `prongname` argument and block syntax.

Before: 

```ruby
multii_logger.info { 'foo' }  # does nothing
multii_logger.info('App') { 'foo' } # ignors the block, outputs 'App' 
```

After: 


```ruby
multii_logger.info { 'foo' }  # outputs "foo"
multii_logger.info('App') { 'foo' } # outputs something like "INFO -- App: foo" (depending on log formatter)
```



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rspec` & `bundle exec rubocop`.

[1]: http://chris.beams.io/posts/git-commit/
